### PR TITLE
Fixing serverside for when table does not require paging

### DIFF
--- a/app/mod_tables/serverside/serverside_table.py
+++ b/app/mod_tables/serverside/serverside_table.py
@@ -133,7 +133,7 @@ class ServerSideTable(object):
         def requires_pagination():
             ''' Check if the table is going to be paginated '''
             if self.request_values['iDisplayStart'] != "":
-                if self.request_values['iDisplayLength'] != -1:
+                if int(self.request_values['iDisplayLength']) != -1:
                     return True
             return False
 


### PR DESCRIPTION
When the paging field's paging field is set to False, the program does not react as expected, since in the comparison self.request_values ['iDisplayLength']! = -1 there was no cast of the value for int.