### PR TITLE
Fix str and int comparison _custom_sort

### DIFF
--- a/app/mod_tables/serverside/serverside_table.py
+++ b/app/mod_tables/serverside/serverside_table.py
@@ -112,8 +112,15 @@ class ServerSideTable(object):
                 column_number = int(self.request_values['iSortCol_' + str(i)])
                 column_name = self.columns[column_number]['column_name']
                 sort_direction = self.request_values['sSortDir_' + str(i)]
-                data = sorted(data,
+                # When string is compared to int/float, catch error and
+                # instead convert all values to string first
+                try:
+                    data = sorted(data,
                               key=lambda x: x[column_name],
+                              reverse=is_reverse(sort_direction))
+                except TypeError:
+                    data = sorted(data,
+                              key=lambda x: str(x[column_name]),
                               reverse=is_reverse(sort_direction))
 
             return data


### PR DESCRIPTION
Sorting Column B from the example was giving an error `(TypeError: '<' not supported between instances of 'int' and 'str')` as it contained both strings and integers. This change catches the error and instead converts all the values to string. Doing it only when one of the values is a string still allows proper digit comparisons when all values are digits (int/float).